### PR TITLE
Update README with working example. Hardcoded timestamp causes a 400 …

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@ Currently implemented:
 
 ## Usage
 
-```
-import "github.com/bellycard/stackdriver"
+```go
+import (
+    "github.com/bellycard/stackdriver"
+    "time"
+)
 
 // Create new Stackdriver API client.
 client := stackdriver.NewStackdriverClient("apikey")
@@ -19,10 +22,12 @@ client := stackdriver.NewStackdriverClient("apikey")
 // Create new Stackdriver API gateway message.
 apiMessages := stackdriver.NewGatewayMessage()
 
+now := time.Now().Unix()
+
 // Populate gateway message with metrics.
-apiMessages.CustomMetric("my-metric1","i-axd939f",1395080486,50)
-apiMessages.CustomMetric("my-metric2","i-afdsf9f",1395080487,6.5)
-apiMessages.CustomMetric("my-metric3","i-a3d923f",1395080484,25)
+apiMessages.CustomMetric("my-metric1", "i-axd939f", now, 50)
+apiMessages.CustomMetric("my-metric2", "i-afdsf9f", now, 6.5)
+apiMessages.CustomMetric("my-metric3", "i-a3d923f", now, 25)
 
 // Send gateway message to Stackdriver API.
 client.Send(apiMessages)


### PR DESCRIPTION
…from the API.
